### PR TITLE
Update container image and remove unused annotation

### DIFF
--- a/quarkus-sse/app_stack.yaml
+++ b/quarkus-sse/app_stack.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: quarkus-app
-          image: tiempor3al/quarkus-kubernetes:v20240612-153928
+          image: tiempor3al/quarkus-kubernetes:e98826ad94ceb254d7d8fe2813c2ce47d2f7c3ec
           ports:
             - containerPort: 8080
 ---
@@ -38,7 +38,6 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: "cloudflare-dns-issuer"
     traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
-    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
Updated the container image for the quarkus-app to match the latest hash. Additionally, removed the unused `traefik.ingress.kubernetes.io/router.middlewares` annotation to clean up the configuration.