### PR TITLE
Update Postgres PVC access mode and add subPath for storage

### DIFF
--- a/postgresql/deployment.yaml
+++ b/postgresql/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     # Kubernetes v1.29+
-    - ReadWriteOncePod
+    - ReadWriteOnce
   resources:
     requests:
       storage: 5Gi
@@ -43,6 +43,7 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgres-storage
+              subPath: postgres
       volumes:
         - name: postgres-storage
           persistentVolumeClaim:


### PR DESCRIPTION
Changed the access mode from ReadWriteOncePod to ReadWriteOnce for compatibility with older Kubernetes versions. Added subPath 'postgres' to maintain proper directory structure in the persistent volume.