### PR TITLE
Update cluster-issuer to Let's Encrypt in app_stack.yaml

### DIFF
--- a/quarkus-sse/app_stack.yaml
+++ b/quarkus-sse/app_stack.yaml
@@ -36,7 +36,7 @@ kind: Ingress
 metadata:
   name: quarkus-ingress
   annotations:
-    cert-manager.io/cluster-issuer: "cloudflare-dns-issuer"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
     traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
 spec:
   ingressClassName: traefik


### PR DESCRIPTION
Replaced the Cloudflare DNS issuer with the Let's Encrypt production issuer for certificate management. This ensures compatibility and leverages Let's Encrypt for the TLS certificates in the ingress configuration.