### PR TITLE
Change service port from 8080 to 8000

### DIFF
--- a/quarkus-sse/app_stack.yaml
+++ b/quarkus-sse/app_stack.yaml
@@ -28,7 +28,7 @@ spec:
     app: quarkus-app
   ports:
     - protocol: TCP
-      port: 8080
+      port: 8000
       targetPort: 8080
 ---
 apiVersion: networking.k8s.io/v1
@@ -54,4 +54,4 @@ spec:
               service:
                 name: quarkus-service
                 port:
-                  number: 8080
+                  number: 8000


### PR DESCRIPTION
Updated `app_stack.yaml` to modify the service port configuration. The changes ensure the service listens on port 8000 instead of 8080, aligning with updated application requirements.