### PR TITLE
Change service type from LoadBalancer to NodePort

### DIFF
--- a/quarkus-sse/app_stack.yaml
+++ b/quarkus-sse/app_stack.yaml
@@ -23,7 +23,7 @@ kind: Service
 metadata:
   name: quarkus-service
 spec:
-  type: LoadBalancer
+  type: NodePort
   selector:
     app: quarkus-app
   ports:


### PR DESCRIPTION
Switched the service type in app_stack.yaml to NodePort to align with the deployment environment requirements. This ensures better compatibility and resource allocation for the current infrastructure setup.