### PR TITLE
Update PostgreSQL PVC storage configuration

### DIFF
--- a/postgresql/deployment.yaml
+++ b/postgresql/deployment.yaml
@@ -3,12 +3,13 @@ kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
 spec:
+  storageClassName: standard
   accessModes:
     # Kubernetes v1.29+
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 20Gi
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Added `storageClassName` with value `standard` and increased storage request from 5Gi to 20Gi. These changes ensure adequate storage capacity and specify the desired storage class for PostgreSQL.