### PR TITLE
Remove storageClassName from PostgreSQL deployment

### DIFF
--- a/postgresql/deployment.yaml
+++ b/postgresql/deployment.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
 spec:
-  storageClassName: standard
   accessModes:
     # Kubernetes v1.29+
     - ReadWriteOnce


### PR DESCRIPTION
The `storageClassName: standard` field was removed from the PVC specification. This ensures compatibility with dynamic storage provisioning and avoids enforcing a specific storage class.