### PR TITLE
Update secret reference for Grafana admin password

### DIFF
--- a/grafana/app_stack.yaml
+++ b/grafana/app_stack.yaml
@@ -27,7 +27,7 @@ spec:
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: grafana-admin-credentials
+                  name: GF_SECURITY_ADMIN_PASSWORD
                   key: grafanapassword
 ---
 apiVersion: v1


### PR DESCRIPTION
Changed the `secretKeyRef` name to use `GF_SECURITY_ADMIN_PASSWORD` instead of `grafana-admin-credentials`. This ensures alignment with the correct secret naming convention and prevents potential configuration issues.