### PR TITLE
Refactor Grafana deployment and add testing configurations

### DIFF
--- a/grafana/app_stack.yaml
+++ b/grafana/app_stack.yaml
@@ -1,72 +1,74 @@
+# this is intended for demo / testing purposes only, not for production usage
+apiVersion: v1
+kind: Service
+metadata:
+  name: lgtm
+spec:
+  selector:
+    app: lgtm
+  ports:
+    - name: grafana
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+    - name: otel-grpc
+      protocol: TCP
+      port: 4317
+      targetPort: 4317
+    - name: otel-http
+      protocol: TCP
+      port: 4318
+      targetPort: 4318
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: otel-lgtm
-  labels:
-    app: otel-lgtm
+  name: lgtm
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: otel-lgtm
+      app: lgtm
   template:
     metadata:
       labels:
-        app: otel-lgtm
+        app: lgtm
     spec:
       containers:
-        - name: otel-lgtm
+        - name: lgtm
           image: grafana/otel-lgtm:latest
           ports:
             - containerPort: 3000
             - containerPort: 4317
             - containerPort: 4318
-          env:
-            - name: GF_SECURITY_ADMIN_USER
-              value: admin
-            - name: GF_SECURITY_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: GF_SECURITY_ADMIN_PASSWORD
-                  key: grafanapassword
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: otel-lgtm
-  labels:
-    app: otel-lgtm
-spec:
-  type: NodePort
-  selector:
-    app: otel-lgtm
-  ports:
-    - name: grafana
-      port: 3000
-      targetPort: 3000
-    - name: otlp-grpc
-      port: 4317
-      targetPort: 4317
-    - name: otlp-http
-      port: 4318
-      targetPort: 4318
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: otel-lgtm
-  annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
-spec:
-  rules:
-    - host: grafana.enjambre.work
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: otel-lgtm
-                port:
-                  number: 3000
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/ready
+          # NOTE: By default OpenShift does not allow writing the root directory.
+          # Thats why the data dirs for grafana, prometheus and loki can not be
+          # created and the pod never becomes ready.
+          # See: https://github.com/grafana/docker-otel-lgtm/issues/132
+          volumeMounts:
+            - name: tempo-data
+              mountPath: /data/tempo
+            - name: grafana-data
+              mountPath: /data/grafana
+            - name: loki-data
+              mountPath: /data/loki
+            - name: loki-storage
+              mountPath: /loki
+            - name: p8s-storage
+              mountPath: /data/prometheus
+      volumes:
+        - name: tempo-data
+          emptyDir: {}
+        - name: loki-data
+          emptyDir: {}
+        - name: grafana-data
+          emptyDir: {}
+        - name: loki-storage
+          emptyDir: {}
+        - name: p8s-storage
+          emptyDir: {}


### PR DESCRIPTION
Simplified and renamed resources by consolidating and standardizing naming. Added volume configurations and readiness probe to support OpenShift compatibility and improve pod readiness. Deprecated Ingress and unnecessary configurations for a leaner setup.